### PR TITLE
Add Robstride armature and frictionloss params

### DIFF
--- a/kbot-v2-feet/meshes/Torso_Side_Right.stl
+++ b/kbot-v2-feet/meshes/Torso_Side_Right.stl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f540e88b5d1436b5d68ef1bed821c1fd503b640d82f203fefbba55d393fe6a23
+oid sha256:d16e170ee67b20289b23717f0d505e0bc1f9b682b94926985a9abe8757a438f3
 size 453884

--- a/kbot-v2-feet/robot.mjcf
+++ b/kbot-v2-feet/robot.mjcf
@@ -2,19 +2,19 @@
   <default>
     <default class="robot">
       <default class="motor_00">
-        <joint armature="0.005" frictionloss="0.1" actuatorfrcrange="-14.0 14.0" />
+        <joint armature="0.001" frictionloss="0.1" actuatorfrcrange="-14.0 14.0" />
         <motor ctrlrange="-14.0 14.0" />
       </default>
       <default class="motor_02">
-        <joint armature="0.0015" frictionloss="0.1" actuatorfrcrange="-17.0 17.0" />
+        <joint armature="0.0042" frictionloss="0.1" actuatorfrcrange="-17.0 17.0" />
         <motor ctrlrange="-17.0 17.0" />
       </default>
       <default class="motor_03">
-        <joint armature="0.005" frictionloss="0.001" actuatorfrcrange="-60.0 60.0" />
+        <joint armature="0.02" frictionloss="0.2" actuatorfrcrange="-60.0 60.0" />
         <motor ctrlrange="-60.0 60.0" />
       </default>
       <default class="motor_04">
-        <joint armature="0.007" frictionloss="0.0015" actuatorfrcrange="-120.0 120.0" />
+        <joint armature="0.04" frictionloss="0.2" actuatorfrcrange="-120.0 120.0" />
         <motor ctrlrange="-120.0 120.0" />
       </default>
       <default class="visual">

--- a/kbot-v2-feet/robot.suspended.mjcf
+++ b/kbot-v2-feet/robot.suspended.mjcf
@@ -2,19 +2,19 @@
   <default>
     <default class="robot">
       <default class="motor_00">
-        <joint armature="0.005" frictionloss="0.1" actuatorfrcrange="-14.0 14.0" />
+        <joint armature="0.001" frictionloss="0.1" actuatorfrcrange="-14.0 14.0" />
         <motor ctrlrange="-14.0 14.0" />
       </default>
       <default class="motor_02">
-        <joint armature="0.0015" frictionloss="0.1" actuatorfrcrange="-17.0 17.0" />
+        <joint armature="0.0042" frictionloss="0.1" actuatorfrcrange="-17.0 17.0" />
         <motor ctrlrange="-17.0 17.0" />
       </default>
       <default class="motor_03">
-        <joint armature="0.005" frictionloss="0.001" actuatorfrcrange="-60.0 60.0" />
+        <joint armature="0.02" frictionloss="0.2" actuatorfrcrange="-60.0 60.0" />
         <motor ctrlrange="-60.0 60.0" />
       </default>
       <default class="motor_04">
-        <joint armature="0.007" frictionloss="0.0015" actuatorfrcrange="-120.0 120.0" />
+        <joint armature="0.04" frictionloss="0.2" actuatorfrcrange="-120.0 120.0" />
         <motor ctrlrange="-120.0 120.0" />
       </default>
       <default class="visual">

--- a/kbot-v2/meshes/Torso_Side_Right.stl
+++ b/kbot-v2/meshes/Torso_Side_Right.stl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f540e88b5d1436b5d68ef1bed821c1fd503b640d82f203fefbba55d393fe6a23
-size 453884
+oid sha256:16094fde1fe368f9115782aefc2e94270e802140d8302b2632664656ac17abd9
+size 454184

--- a/kbot-v2/robot.mjcf
+++ b/kbot-v2/robot.mjcf
@@ -2,19 +2,19 @@
   <default>
     <default class="robot">
       <default class="motor_00">
-        <joint armature="0.005" frictionloss="0.1" actuatorfrcrange="-14.0 14.0" />
+        <joint armature="0.001" frictionloss="0.1" actuatorfrcrange="-14.0 14.0" />
         <motor ctrlrange="-14.0 14.0" />
       </default>
       <default class="motor_02">
-        <joint armature="0.0015" frictionloss="0.1" actuatorfrcrange="-17.0 17.0" />
+        <joint armature="0.0042" frictionloss="0.1" actuatorfrcrange="-17.0 17.0" />
         <motor ctrlrange="-17.0 17.0" />
       </default>
       <default class="motor_03">
-        <joint armature="0.005" frictionloss="0.001" actuatorfrcrange="-60.0 60.0" />
+        <joint armature="0.02" frictionloss="0.2" actuatorfrcrange="-60.0 60.0" />
         <motor ctrlrange="-60.0 60.0" />
       </default>
       <default class="motor_04">
-        <joint armature="0.007" frictionloss="0.0015" actuatorfrcrange="-120.0 120.0" />
+        <joint armature="0.04" frictionloss="0.2" actuatorfrcrange="-120.0 120.0" />
         <motor ctrlrange="-120.0 120.0" />
       </default>
       <default class="visual">

--- a/kbot-v2/robot.suspended.mjcf
+++ b/kbot-v2/robot.suspended.mjcf
@@ -2,19 +2,19 @@
   <default>
     <default class="robot">
       <default class="motor_00">
-        <joint armature="0.005" frictionloss="0.1" actuatorfrcrange="-14.0 14.0" />
+        <joint armature="0.001" frictionloss="0.1" actuatorfrcrange="-14.0 14.0" />
         <motor ctrlrange="-14.0 14.0" />
       </default>
       <default class="motor_02">
-        <joint armature="0.0015" frictionloss="0.1" actuatorfrcrange="-17.0 17.0" />
+        <joint armature="0.0042" frictionloss="0.1" actuatorfrcrange="-17.0 17.0" />
         <motor ctrlrange="-17.0 17.0" />
       </default>
       <default class="motor_03">
-        <joint armature="0.005" frictionloss="0.001" actuatorfrcrange="-60.0 60.0" />
+        <joint armature="0.02" frictionloss="0.2" actuatorfrcrange="-60.0 60.0" />
         <motor ctrlrange="-60.0 60.0" />
       </default>
       <default class="motor_04">
-        <joint armature="0.007" frictionloss="0.0015" actuatorfrcrange="-120.0 120.0" />
+        <joint armature="0.04" frictionloss="0.2" actuatorfrcrange="-120.0 120.0" />
         <motor ctrlrange="-120.0 120.0" />
       </default>
       <default class="visual">


### PR DESCRIPTION
https://github.com/kscalelabs/urdfs/pull/48


We're only about 60% confident about the SysId results below compared to a prefect sim2real setup.

### Problem
https://linear.app/k-scale/issue/K-249/ask-robstride-what-the-motors-rotor-inertia-is

### Solution
After consulting Robstride, we've received the below results:

```
Armature:

00: 0.001 kg*m2

01 02：低速端等效惯量4.2e-3 kg*m2

03: 0.02 kg*m2

04：低速端等效惯量 0.04 kg*m2

This was calculated based on motor CAD, according to WangBo.

Damping:

This value should be very small (near 0). This should be experimented and tested. 

Frictionloss:

0.1-0.2
```

### Validation
Our validation and writeup is below:

https://linear.app/k-scale/issue/K-182/characterize-and-add-mjcf-damping-value
https://linear.app/k-scale/issue/K-173/frictionloss-characterization-currently-might-not-be-correct
https://linear.app/k-scale/issue/K-266/update-armatur-friction-and-damping-values-of-mjcf